### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Run pipeline
+name: Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -2,8 +2,6 @@ name: Run pipeline
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
   schedule:
     - cron: "0 12 * * *"
 
@@ -32,6 +30,12 @@ jobs:
         run: |
           set -euo pipefail
           git pull
+
+      - name: Re-build images
+        working-directory: /srv/projects/icc-eval-core
+        run: |
+          set -euo pipefail
+          ./run_stack.sh build
 
       - name: Run pipeline in Compose stack
         working-directory: /srv/projects/icc-eval-core


### PR DESCRIPTION
- remove push-to-main trigger (workflow already runs daily and on command)
- rename workflow to "deploy", to keep distinct from "pipeline" (which we use to just refer to the data "ingestion")
- re-build docker images every workflow run

@falquaddoomi Is it possible to also add a command right in the workflow that always sets the appropriate user permissions to avoid more run failures?