### PR TITLE
Redeploys stack on pipeline run, other cleanups

### DIFF
--- a/.env.TEMPLATE
+++ b/.env.TEMPLATE
@@ -1,7 +1,6 @@
 DEFAULT_ENV=dev
 
 DOMAIN=metrics.cfdeconnect.org
-ALT_DOMAIN=cfde-api.cu-dbmi.dev
 
 DJANGO_SECRET_KEY=
 DJANGO_SUPERUSER_USERNAME=admin

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,6 +86,24 @@ jobs:
             echo "::endgroup::"
           ) 200>"$LOCK_FILE"
 
+      - name: Relaunch the stack for serving
+        working-directory: /srv/projects/icc-eval-core
+        run: |
+          set -euo pipefail
+
+          LOCK_FILE=/tmp/icc-eval-core-api-pipeline.lock
+
+          (
+            if ! flock -n 200; then
+              echo "Another pipeline run is already active on this VM. Exiting without starting a new run."
+              exit 78
+            fi
+
+            echo "::group::Pipeline logs"
+            ./run_stack.sh 2>&1 | tee launch.log
+            echo "::endgroup::"
+          ) 200>"$LOCK_FILE"
+
       - name: Upload import log
         uses: actions/upload-artifact@v4
         if: always()

--- a/backend/icc_eval_core_api/icc_eval_core_api/settings.py
+++ b/backend/icc_eval_core_api/icc_eval_core_api/settings.py
@@ -71,6 +71,8 @@ ALLOWED_HOSTS = [
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
     "http://localhost:5175",
     "http://127.0.0.1:5175",
     "https://cfde-eval.netlify.app",

--- a/backend/icc_eval_core_api/icc_eval_core_api/settings.py
+++ b/backend/icc_eval_core_api/icc_eval_core_api/settings.py
@@ -63,11 +63,9 @@ INSTALLED_APPS = [
 ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
-    'cfde-api.cu-dbmi.dev',
     'cfde-eval.netlify.app',
     'metrics.cfdeconnect.org',
     os.environ.get("DOMAIN", ""),
-    os.environ.get("ALT_DOMAIN", ""),
 ]
 
 CORS_ALLOWED_ORIGINS = [
@@ -76,7 +74,6 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5175",
     "http://127.0.0.1:5175",
     "https://cfde-eval.netlify.app",
-    "https://cfde-api.cu-dbmi.dev",
     "https://metrics.cfdeconnect.org",
 ]
 
@@ -92,7 +89,6 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:5173",
     "http://127.0.0.1:5175",
     "https://cfde-eval.netlify.app",
-    "https://cfde-api.cu-dbmi.dev",
     "https://metrics.cfdeconnect.org",
 ]
 

--- a/backend/icc_eval_core_api/icc_eval_core_api/settings.py
+++ b/backend/icc_eval_core_api/icc_eval_core_api/settings.py
@@ -214,10 +214,26 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    # causes keys to be rewritten as camelCase in the JSON response
     'DEFAULT_RENDERER_CLASSES': [
         'djangorestframework_camel_case.render.CamelCaseJSONRenderer',
         'djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer',
     ],
+    "JSON_UNDERSCOREIZE": {
+        # causes fields with this name to not have underscores in their keys converted
+        # to camelCase in the JSON response
+        "ignore_fields": (
+            "overTime",
+            "continents",
+            "countries",
+            "regions",
+            "cities",
+            "languages",
+            "devices",
+            "operatingSystems",
+            "pageViews",
+        ),
+    },
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
 }

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -10,7 +10,7 @@
 }
 
 # Production (HTTPS + automatic certs)
-{$DOMAIN}, {$ALT_DOMAIN} {
+{$DOMAIN} {
 	@backend_paths {
 		path /api/* /admin/* /api-auth/* /accounts/*
 	}


### PR DESCRIPTION
This PR mostly adds a step to the `deploy.yaml` workflow to relaunch the stack's components, if needed, via the usual `run-stack.sh` command. (We'll likely split deployment and pipeline running into separate workflows in the near future, but this should fix, e.g., the frontend unexpectedly not being updated after a so-called deploy run.)

The PR also removes handling for a second, alternative domain that we had to use when the frontend was being served from a different origin than the API. Now that that's no longer the case, that mechanism is no longer needed. I've also removed references to the old domain from various places.

Finally, the PR allows frontend access on origins `localhost:5173` and `127.0.0.1:5173`, i.e. the standard Vite ports.
